### PR TITLE
Render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 1.0.0 (2023-04-29)
+
+
+### Features
+
+* Added obsidian furigana syntax support ([6eb8cc9](https://github.com/daviddavo/logseq-furigana/commit/6eb8cc9eedcdab79996db760394af9a990e3cf69))
+
 # 0.0.1 - 2023-04-29
 Initial release
 - Added the Obsidian Furigana and Anki Furigana slash commands

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [1.0.1](https://github.com/daviddavo/logseq-furigana/compare/v1.0.0...v1.0.1) (2023-05-28)
+
+
+### Bug Fixes
+
+* Missing logseq plugin title ([c473aa5](https://github.com/daviddavo/logseq-furigana/commit/c473aa59145a1acd0d05b4c60c301a3a2f990f51))
+* **UI:** Removed button from toolbar [#2](https://github.com/daviddavo/logseq-furigana/issues/2) ([2e43d6c](https://github.com/daviddavo/logseq-furigana/commit/2e43d6c5212cfa92803a1da3e63f7508cb38a690))
+
 # 1.0.0 (2023-04-29)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "logseq-furigana",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "dist/index.html",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "logseq-furigana",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "main": "dist/index.html",
   "scripts": {
     "dev": "vite",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -49,13 +49,6 @@ function main() {
     }
   `);
 
-  logseq.App.registerUIItem("toolbar", {
-    key: openIconName,
-    template: `
-      <div data-on-click="show" class="${openIconName}">⚙️</div>
-    `,
-  });
-
   function createRubySlashCommand (fp: CommonParser) {
     return logseq.Editor.registerSlashCommand(
       `${fp.slashCommandTitle} to ruby`,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,8 +7,10 @@ import "./index.css";
 
 import { AnkiFuriganaParser } from "./parsers/AnkiFuriganaParser";
 import { ObsidianFuriganaParser } from "./parsers/ObsidianFuriganaParser";
+import { MarukakkoFuriganaParser } from "./parsers/MarukakkoFuriganaParser";
 import { logseq as PL } from "../package.json";
 import { CommonParser } from "./parsers/CommonParser";
+import { SumitsukikakkoFuriganaParser } from "./parsers/SumitsukikakkoFuriganaParser";
 
 // @ts-expect-error
 const css = (t, ...args) => String.raw(t, ...args);
@@ -70,7 +72,11 @@ async function main() {
   const parsers = [ 
     new AnkiFuriganaParser(),
     new ObsidianFuriganaParser(),
+    new MarukakkoFuriganaParser(),
+    new SumitsukikakkoFuriganaParser(),
   ]
+
+  parsers.map(createRubySlashCommand)
 
   const observer = new MutationObserver((mutationList, observer) => {
     for (const m of mutationList) {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,7 +8,6 @@ import "./index.css";
 import { AnkiFuriganaParser } from "./parsers/AnkiFuriganaParser";
 import { ObsidianFuriganaParser } from "./parsers/ObsidianFuriganaParser";
 import { MarukakkoFuriganaParser } from "./parsers/MarukakkoFuriganaParser";
-import { logseq as PL } from "../package.json";
 import { CommonParser } from "./parsers/CommonParser";
 import { SumitsukikakkoFuriganaParser } from "./parsers/SumitsukikakkoFuriganaParser";
 
@@ -88,8 +87,8 @@ async function main() {
             content.style.border = '1px solid red'
             for (const fp of parsers) {
               if (fp.hasFurigana(content.innerHTML)) {
-                  fp.replaceHtml(content)
-                  content.style.border = '1px solid green'
+                fp.replaceHtml(content)
+                content.style.border = '1px solid green'
               }
             }
           }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -13,7 +13,7 @@ import { CommonParser } from "./parsers/CommonParser";
 // @ts-expect-error
 const css = (t, ...args) => String.raw(t, ...args);
 
-function main() {
+async function main() {
   const root = ReactDOM.createRoot(document.getElementById("app")!);
 
   root.render(
@@ -67,8 +67,66 @@ function main() {
     )
   }
 
-  createRubySlashCommand(new AnkiFuriganaParser());
-  createRubySlashCommand(new ObsidianFuriganaParser());
+  const parsers = [ 
+    new AnkiFuriganaParser(),
+    new ObsidianFuriganaParser(),
+  ]
+
+  const observer = new MutationObserver((mutationList, observer) => {
+    for (const m of mutationList) {
+      for (const node of m.addedNodes) {
+        if (node.nodeType === Node.ELEMENT_NODE) {
+          const element = node as HTMLElement 
+
+          for (const content of element.querySelectorAll('span.inline') as NodeListOf<HTMLElement>) {
+            content.style.border = '1px solid red'
+            for (const fp of parsers) {
+              if (fp.hasFurigana(content.innerHTML)) {
+                  fp.replaceHtml(content)
+                  content.style.border = '1px solid green'
+              }
+            }
+          }
+        }
+      }
+    }
+  })
+
+  observer.observe(top!.document.body, {childList: true, subtree: true, })
+
+  // TODO: Use also on block edited
+  // logseq.App.onRouteChanged(async (e) => {
+  //   console.log(e)
+
+  //   const inlines = document.querySelectorAll("span.inline")
+  //   for (const i of inlines) {
+  //     console.log(`Setting up observer for ${i}`)
+  //     mo.observe(i, { childList: true, subtree: true, attributes: true, })
+  //   }
+
+  //   const blocks = await logseq.Editor.getCurrentPageBlocksTree();
+  //   for (const block of blocks) {
+  //     if (/\.debug/.test(block.content)) {
+  //       logseq.App.onBlockRendererSlotted(
+  //         block.uuid,
+  //         ({slot, ...rest}) => {
+  //           console.log(`Slotted: ${slot} (${rest.content})`)
+  //           logseq.provideUI({
+  //             slot, 
+  //             template: `
+  //               <pre style="border: 1px solid red;">${JSON.stringify(block, null, 2)}</pre>
+  //             `,
+  //             reset: true,
+  //           })
+  //         }
+  //       )
+  //     }
+  //   }
+
+  //   return () => {
+  //     console.log("Off hook")
+  //   }
+  // })
 
   console.info('logseq-furigana loaded');
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -55,12 +55,14 @@ async function main() {
       `${fp.slashCommandTitle} to ruby`,
       async ({pid, format, uuid}) => {
         const content = await logseq.Editor.getEditingBlockContent();
-        const withFurigana = fp.toHtml(content);
 
-        if (withFurigana) {
-          const newContent = `<span>${withFurigana}</span>`
+        if (fp.hasFurigana(content)) {
+          const aux = document.createElement('span')
+          aux.innerHTML = content;
+          fp.replaceHtml(aux);
+
           // logseq.Editor.insertBlock(uuid, newContent);
-          logseq.Editor.updateBlock(uuid, newContent);
+          logseq.Editor.updateBlock(uuid, aux.innerHTML);
         } else {
           logseq.UI.showMsg('No furigana detected', 'warning');
         }
@@ -83,7 +85,7 @@ async function main() {
         if (node.nodeType === Node.ELEMENT_NODE) {
           const element = node as HTMLElement 
 
-          for (const content of element.querySelectorAll('span.inline') as NodeListOf<HTMLElement>) {
+          for (const content of element.querySelectorAll('div.block-content') as NodeListOf<HTMLElement>) {
             content.style.border = '1px solid red'
             for (const fp of parsers) {
               if (fp.hasFurigana(content.innerHTML)) {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -62,7 +62,6 @@ async function main() {
           aux.innerHTML = content;
           fp.replaceHtml(aux);
 
-          // logseq.Editor.insertBlock(uuid, newContent);
           logseq.Editor.updateBlock(uuid, aux.innerHTML);
         } else {
           logseq.UI.showMsg('No furigana detected', 'warning');
@@ -119,11 +118,11 @@ async function main() {
           const element = node as HTMLElement 
 
           for (const content of element.querySelectorAll('div.block-content') as NodeListOf<HTMLElement>) {
-            content.style.border = '1px solid red'
+            // content.style.border = '1px solid red'
             for (const fp of enabledParsers) {
               if (fp.hasFurigana(content.innerHTML)) {
                 fp.replaceHtml(content)
-                content.style.border = '1px solid green'
+                // content.style.border = '1px solid green'
               }
             }
           }
@@ -133,40 +132,6 @@ async function main() {
   })
 
   observer.observe(top!.document.body, {childList: true, subtree: true, })
-
-  // TODO: Use also on block edited
-  // logseq.App.onRouteChanged(async (e) => {
-  //   console.log(e)
-
-  //   const inlines = document.querySelectorAll("span.inline")
-  //   for (const i of inlines) {
-  //     console.log(`Setting up observer for ${i}`)
-  //     mo.observe(i, { childList: true, subtree: true, attributes: true, })
-  //   }
-
-  //   const blocks = await logseq.Editor.getCurrentPageBlocksTree();
-  //   for (const block of blocks) {
-  //     if (/\.debug/.test(block.content)) {
-  //       logseq.App.onBlockRendererSlotted(
-  //         block.uuid,
-  //         ({slot, ...rest}) => {
-  //           console.log(`Slotted: ${slot} (${rest.content})`)
-  //           logseq.provideUI({
-  //             slot, 
-  //             template: `
-  //               <pre style="border: 1px solid red;">${JSON.stringify(block, null, 2)}</pre>
-  //             `,
-  //             reset: true,
-  //           })
-  //         }
-  //       )
-  //     }
-  //   }
-
-  //   return () => {
-  //     console.log("Off hook")
-  //   }
-  // })
 
   console.info('logseq-furigana loaded');
 }

--- a/src/parsers/AnkiFuriganaParser.tsx
+++ b/src/parsers/AnkiFuriganaParser.tsx
@@ -7,11 +7,45 @@ export class AnkiFuriganaParser extends CommonParser {
         return 'Anki furigana';
     }
 
-    toHtml(content: string) : string | null {
-        if (this.ankiFuriganaRegex.test(content)) {
-            return content.replace(this.ankiFuriganaRegex, this.furiganaHTMLTemplateSimple);
+    hasFurigana(content: string): boolean {
+        return this.ankiFuriganaRegex.test(content);
+    }
+
+    toNode(text: Text) : Node {
+        console.log("Inside toNode: " + text.textContent!)
+        console.log(text.textContent!.match(this.ankiFuriganaRegex))
+        let last = text
+
+        for (const match of text.textContent!.matchAll(this.ankiFuriganaRegex) ) {
+            console.log(match)
+            const kanji = match[1]
+            const furi = match[2]
+
+            // Create the ruby
+            const ruby = document.createElement('ruby')
+            // ruby.appendChild(document.createTextNode("Holi?"))
+            ruby.innerHTML = `${kanji}<rt>${furi}</rt>`
+
+            // Replace it
+            const start = last.textContent!.indexOf(match[0])
+            const end = match[0].length
+
+            const toReplace = last.splitText(start)
+
+            last = toReplace.splitText(end)
+            toReplace.replaceWith(ruby)
+            console.log(ruby)
+            console.log(start)
+            console.log(end)
+            console.log(toReplace)
+            console.log(last)
+            console.log(text)
         }
 
-        return null;
+        return text
+    }
+
+    toHtml(content: string) : string {
+        return content.replace(this.ankiFuriganaRegex, this.furiganaHTMLTemplateSimple);
     }
 }

--- a/src/parsers/AnkiFuriganaParser.tsx
+++ b/src/parsers/AnkiFuriganaParser.tsx
@@ -1,6 +1,10 @@
 import { SimpleRegexParser } from "./SimpleRegexParser";
 
 export class AnkiFuriganaParser extends SimpleRegexParser {
+    get slashCommandTitle() : string {
+        return "Anki furigana"
+    }
+
     get regex() : RegExp {
         return /(\S+)\[(\S+)\]/gm
     }

--- a/src/parsers/AnkiFuriganaParser.tsx
+++ b/src/parsers/AnkiFuriganaParser.tsx
@@ -1,51 +1,7 @@
-import { CommonParser } from "./CommonParser";
+import { SimpleRegexParser } from "./SimpleRegexParser";
 
-export class AnkiFuriganaParser extends CommonParser {
-    readonly ankiFuriganaRegex : RegExp = /(\S+)\[(\S+)\]/gm;
-
-    get slashCommandTitle () {
-        return 'Anki furigana';
-    }
-
-    hasFurigana(content: string): boolean {
-        return this.ankiFuriganaRegex.test(content);
-    }
-
-    toNode(text: Text) : Node {
-        console.log("Inside toNode: " + text.textContent!)
-        console.log(text.textContent!.match(this.ankiFuriganaRegex))
-        let last = text
-
-        for (const match of text.textContent!.matchAll(this.ankiFuriganaRegex) ) {
-            console.log(match)
-            const kanji = match[1]
-            const furi = match[2]
-
-            // Create the ruby
-            const ruby = document.createElement('ruby')
-            // ruby.appendChild(document.createTextNode("Holi?"))
-            ruby.innerHTML = `${kanji}<rt>${furi}</rt>`
-
-            // Replace it
-            const start = last.textContent!.indexOf(match[0])
-            const end = match[0].length
-
-            const toReplace = last.splitText(start)
-
-            last = toReplace.splitText(end)
-            toReplace.replaceWith(ruby)
-            console.log(ruby)
-            console.log(start)
-            console.log(end)
-            console.log(toReplace)
-            console.log(last)
-            console.log(text)
-        }
-
-        return text
-    }
-
-    toHtml(content: string) : string {
-        return content.replace(this.ankiFuriganaRegex, this.furiganaHTMLTemplateSimple);
+export class AnkiFuriganaParser extends SimpleRegexParser {
+    get regex() : RegExp {
+        return /(\S+)\[(\S+)\]/gm
     }
 }

--- a/src/parsers/AnkiFuriganaParser.tsx
+++ b/src/parsers/AnkiFuriganaParser.tsx
@@ -1,6 +1,14 @@
 import { SimpleRegexParser } from "./SimpleRegexParser";
 
 export class AnkiFuriganaParser extends SimpleRegexParser {
+    get configKey() : string {
+        return "anki"
+    }
+
+    get description() : string {
+        return "Uses Anki's syntax for furigana: `漢字[かんじ]`"
+    }
+
     get slashCommandTitle() : string {
         return "Anki furigana"
     }

--- a/src/parsers/CommonParser.tsx
+++ b/src/parsers/CommonParser.tsx
@@ -1,8 +1,28 @@
 export abstract class CommonParser {
     readonly furiganaHTMLTemplateSimple : string = "<ruby>$1<rt>$2</ruby>";
+    readonly codeRegex : RegExp = /`.*?`/gm
 
     abstract get slashCommandTitle() : string;
-    abstract toHtml(content: string) : string | null;
+    abstract toNode(text: Text) : Node
+
+    // Both these commands should work both with Markdown and with HTML
+    abstract toHtml(content: string) : string
+    abstract hasFurigana(content: string) : boolean
+
+    replaceHtml(node: ChildNode) {
+        // Based on https://github.com/steven-kraft/obsidian-markdown-furigana/blob/f3a0bbbf6c28e9a3d0c18994a1f6c89365171ed2/main.ts#L39-L58
+        if (['CODE', 'RUBY', 'A'].includes(node.nodeName)) {
+            return
+        }
+
+        if (node.hasChildNodes()) {
+            for (const child of node.childNodes) {
+                this.replaceHtml(child)
+            }
+        } else {
+            node.replaceWith(this.toNode(node as Text))
+        }
+    }
 
     fromHtml(content: string) : string | null {
         throw new Error('Not Implemented');

--- a/src/parsers/CommonParser.tsx
+++ b/src/parsers/CommonParser.tsx
@@ -1,15 +1,11 @@
 export abstract class CommonParser {
-    readonly furiganaHTMLTemplateSimple : string = "<ruby>$1<rt>$2</ruby>";
-    readonly codeRegex : RegExp = /`.*?`/gm
+    public abstract get slashCommandTitle() : string;
+    protected abstract toNode(text: Text) : Node
 
-    abstract get slashCommandTitle() : string;
-    abstract toNode(text: Text) : Node
+    // This commands should work both with Markdown and with HTML
+    public abstract hasFurigana(content: string) : boolean
 
-    // Both these commands should work both with Markdown and with HTML
-    abstract toHtml(content: string) : string
-    abstract hasFurigana(content: string) : boolean
-
-    replaceHtml(node: ChildNode) {
+    public replaceHtml(node: ChildNode) {
         // Based on https://github.com/steven-kraft/obsidian-markdown-furigana/blob/f3a0bbbf6c28e9a3d0c18994a1f6c89365171ed2/main.ts#L39-L58
         if (['CODE', 'RUBY', 'A'].includes(node.nodeName)) {
             return
@@ -22,9 +18,5 @@ export abstract class CommonParser {
         } else {
             node.replaceWith(this.toNode(node as Text))
         }
-    }
-
-    fromHtml(content: string) : string | null {
-        throw new Error('Not Implemented');
     }
 }

--- a/src/parsers/CommonParser.tsx
+++ b/src/parsers/CommonParser.tsx
@@ -1,5 +1,7 @@
 export abstract class CommonParser {
-    public abstract get slashCommandTitle() : string;
+    public abstract get configKey() : string
+    public abstract get description() : string
+    public abstract get slashCommandTitle() : string
     protected abstract toNode(text: Text) : Node
 
     // This commands should work both with Markdown and with HTML

--- a/src/parsers/MarukakkoFuriganaParser.tsx
+++ b/src/parsers/MarukakkoFuriganaParser.tsx
@@ -1,6 +1,15 @@
 import { SimpleRegexParser } from "./SimpleRegexParser";
 
 export class MarukakkoFuriganaParser extends SimpleRegexParser {
+    get configKey() : string {
+        return "marukakko"
+    }
+
+    get description() : string {
+        return "Uses Japanese round parenthesis `漢字（かんじ）`\n\
+        Keep in mind that this is not the same as normal ASCII parentheses, you have to set the japanese input method"
+    }
+
     get slashCommandTitle() : string {
         return "Marukakko Furigana (Japanese round parenthesis)"
     }

--- a/src/parsers/MarukakkoFuriganaParser.tsx
+++ b/src/parsers/MarukakkoFuriganaParser.tsx
@@ -1,0 +1,7 @@
+import { SimpleRegexParser } from "./SimpleRegexParser";
+
+export class MarukakkoFuriganaParser extends SimpleRegexParser {
+    get regex() : RegExp {
+        return /(\S+)\u{ff08}(\S+)\u{ff09}/gmu
+    }
+}

--- a/src/parsers/MarukakkoFuriganaParser.tsx
+++ b/src/parsers/MarukakkoFuriganaParser.tsx
@@ -1,6 +1,10 @@
 import { SimpleRegexParser } from "./SimpleRegexParser";
 
 export class MarukakkoFuriganaParser extends SimpleRegexParser {
+    get slashCommandTitle() : string {
+        return "Marukakko Furigana (Japanese round parenthesis)"
+    }
+
     get regex() : RegExp {
         return /(\S+)\u{ff08}(\S+)\u{ff09}/gmu
     }

--- a/src/parsers/ObsidianFuriganaParser.tsx
+++ b/src/parsers/ObsidianFuriganaParser.tsx
@@ -9,9 +9,15 @@ export class ObsidianFuriganaParser extends CommonParser {
         return 'Obsidian furigana';
     }
 
-    toHtml(content: string): string | null {
-        let changes = false;
+    hasFurigana(content: string): boolean {
+        return this.obsidianFuriganaRegex.test(content);
+    }
 
+    toNode(text: Text): Node {
+        throw new Error('Not Implemented');
+    }
+
+    toHtml(content: string): string {
         let m = this.obsidianFuriganaRegex.exec(content);
         while (m) {
             const furi = m[2].split('|').slice(1); // First element is always empty
@@ -31,12 +37,11 @@ export class ObsidianFuriganaParser extends CommonParser {
                 const end = this.obsidianFuriganaRegex.lastIndex;
                 content = content.substring(0, start) + ruby.outerHTML + content.substring(end);
                 this.obsidianFuriganaRegex.lastIndex = start + ruby.outerHTML.length;
-                changes = true;
             }
 
             m = this.obsidianFuriganaRegex.exec(content);
         }
 
-        return changes ? content : null;
+        return content;
     }
 }

--- a/src/parsers/ObsidianFuriganaParser.tsx
+++ b/src/parsers/ObsidianFuriganaParser.tsx
@@ -2,6 +2,13 @@ import { SimpleRegexParser } from "./SimpleRegexParser";
 
 // Based on https://github.com/steven-kraft/obsidian-markdown-furigana
 export class ObsidianFuriganaParser extends SimpleRegexParser {
+    get configKey() : string {
+        return "obsidian"
+    }
+
+    get description() : string {
+        return "Uses a syntax like [Obsidian's furigana](https://github.com/steven-kraft/obsidian-markdown-furigana) plugin: `{漢字|かんじ}` or `{漢字|かん|じ}`"
+    }
 
     get regex() : RegExp {
         // From https://github.com/steven-kraft/obsidian-markdown-furigana/blob/4c274274ea33feb826631a7d7b5c4bac28742346/main.ts#L4
@@ -10,33 +17,5 @@ export class ObsidianFuriganaParser extends SimpleRegexParser {
 
     get slashCommandTitle(): string {
         return 'Obsidian furigana';
-    }
-
-    toHtml(content: string): string {
-        let m = this.regex.exec(content);
-        while (m) {
-            const furi = m[2].split('|').slice(1); // First element is always empty
-            const kanji = furi.length === 1 ? [m[1]] : m[1].split('');
-
-            if (furi.length == kanji.length) {
-                const ruby = document.createElement('ruby');
-
-                kanji.forEach((k,i) => {
-                    ruby.appendChild(document.createTextNode(k));
-                    const rt = document.createElement('rt');
-                    rt.appendChild(document.createTextNode(furi[i]));
-                    ruby.appendChild(rt);
-                })
-
-                const start = this.regex.lastIndex - m[0].length;
-                const end = this.regex.lastIndex;
-                content = content.substring(0, start) + ruby.outerHTML + content.substring(end);
-                this.regex.lastIndex = start + ruby.outerHTML.length;
-            }
-
-            m = this.regex.exec(content);
-        }
-
-        return content;
     }
 }

--- a/src/parsers/ObsidianFuriganaParser.tsx
+++ b/src/parsers/ObsidianFuriganaParser.tsx
@@ -14,7 +14,39 @@ export class ObsidianFuriganaParser extends CommonParser {
     }
 
     toNode(text: Text): Node {
-        throw new Error('Not Implemented');
+        let last = text
+        console.log("Inside toNode" + text.textContent!)
+        console.log(text.textContent!.match(this.obsidianFuriganaRegex))
+
+        for (const match of text.textContent!.matchAll(this.obsidianFuriganaRegex)) {
+            const furi = match[2].split('|').slice(1)
+            const kanji = furi.length === 1 ? [match[1]] : match[1].split('')
+
+            const ruby = document.createElement('ruby')
+            kanji.forEach((k,i) => {
+                ruby.appendChild(document.createTextNode(k));
+                const rt = document.createElement('rt')
+                rt.appendChild(document.createTextNode(furi[i]))
+                ruby.appendChild(rt)
+            })
+
+            const start = last.textContent!.indexOf(match[0])
+            const end = match[0].length
+
+            const toReplace = last.splitText(start)
+
+            last = toReplace.splitText(end)
+            toReplace.replaceWith(ruby)
+
+            console.log(ruby)
+            console.log(start)
+            console.log(end)
+            console.log(toReplace)
+            console.log(last)
+            console.log(text)
+        }
+
+        return text
     }
 
     toHtml(content: string): string {

--- a/src/parsers/ObsidianFuriganaParser.tsx
+++ b/src/parsers/ObsidianFuriganaParser.tsx
@@ -1,56 +1,19 @@
-import { CommonParser } from "./CommonParser";
+import { SimpleRegexParser } from "./SimpleRegexParser";
 
 // Based on https://github.com/steven-kraft/obsidian-markdown-furigana
-export class ObsidianFuriganaParser extends CommonParser {
-    // From https://github.com/steven-kraft/obsidian-markdown-furigana/blob/4c274274ea33feb826631a7d7b5c4bac28742346/main.ts#L4
-    readonly obsidianFuriganaRegex : RegExp = /{((?:[\u2E80-\uA4CF\uFF00-\uFFEF])+)((?:\|[^ -\/{-~:-@\[-`]*)+)}/gm;
+export class ObsidianFuriganaParser extends SimpleRegexParser {
+
+    get regex() : RegExp {
+        // From https://github.com/steven-kraft/obsidian-markdown-furigana/blob/4c274274ea33feb826631a7d7b5c4bac28742346/main.ts#L4
+        return /{((?:[\u2E80-\uA4CF\uFF00-\uFFEF])+)((?:\|[^ -\/{-~:-@\[-`]*)+)}/gm;
+    }
 
     get slashCommandTitle(): string {
         return 'Obsidian furigana';
     }
 
-    hasFurigana(content: string): boolean {
-        return this.obsidianFuriganaRegex.test(content);
-    }
-
-    toNode(text: Text): Node {
-        let last = text
-        console.log("Inside toNode" + text.textContent!)
-        console.log(text.textContent!.match(this.obsidianFuriganaRegex))
-
-        for (const match of text.textContent!.matchAll(this.obsidianFuriganaRegex)) {
-            const furi = match[2].split('|').slice(1)
-            const kanji = furi.length === 1 ? [match[1]] : match[1].split('')
-
-            const ruby = document.createElement('ruby')
-            kanji.forEach((k,i) => {
-                ruby.appendChild(document.createTextNode(k));
-                const rt = document.createElement('rt')
-                rt.appendChild(document.createTextNode(furi[i]))
-                ruby.appendChild(rt)
-            })
-
-            const start = last.textContent!.indexOf(match[0])
-            const end = match[0].length
-
-            const toReplace = last.splitText(start)
-
-            last = toReplace.splitText(end)
-            toReplace.replaceWith(ruby)
-
-            console.log(ruby)
-            console.log(start)
-            console.log(end)
-            console.log(toReplace)
-            console.log(last)
-            console.log(text)
-        }
-
-        return text
-    }
-
     toHtml(content: string): string {
-        let m = this.obsidianFuriganaRegex.exec(content);
+        let m = this.regex.exec(content);
         while (m) {
             const furi = m[2].split('|').slice(1); // First element is always empty
             const kanji = furi.length === 1 ? [m[1]] : m[1].split('');
@@ -65,13 +28,13 @@ export class ObsidianFuriganaParser extends CommonParser {
                     ruby.appendChild(rt);
                 })
 
-                const start = this.obsidianFuriganaRegex.lastIndex - m[0].length;
-                const end = this.obsidianFuriganaRegex.lastIndex;
+                const start = this.regex.lastIndex - m[0].length;
+                const end = this.regex.lastIndex;
                 content = content.substring(0, start) + ruby.outerHTML + content.substring(end);
-                this.obsidianFuriganaRegex.lastIndex = start + ruby.outerHTML.length;
+                this.regex.lastIndex = start + ruby.outerHTML.length;
             }
 
-            m = this.obsidianFuriganaRegex.exec(content);
+            m = this.regex.exec(content);
         }
 
         return content;

--- a/src/parsers/SimpleRegexParser.tsx
+++ b/src/parsers/SimpleRegexParser.tsx
@@ -10,8 +10,6 @@ export abstract class SimpleRegexParser extends CommonParser {
 
     toNode(text: Text) : Node {
         let last = text
-        console.log("Inside toNode" + text.textContent!)
-        console.log(text.textContent!.match(this.regex))
 
         for (const match of text.textContent!.matchAll(this.regex)) {
             const furi = match[2].includes('|') ? match[2].split('|').slice(1) : [ match[2] ]
@@ -32,19 +30,8 @@ export abstract class SimpleRegexParser extends CommonParser {
 
             last = toReplace.splitText(end)
             toReplace.replaceWith(ruby)
-
-            console.log(ruby)
-            console.log(start)
-            console.log(end)
-            console.log(toReplace)
-            console.log(last)
-            console.log(text)
         }
 
         return text
-    }
-
-    toHtml(content: string) : string {
-        return content.replace(this.regex, this.furiganaHTMLTemplateSimple);
     }
 }

--- a/src/parsers/SimpleRegexParser.tsx
+++ b/src/parsers/SimpleRegexParser.tsx
@@ -4,10 +4,6 @@ export abstract class SimpleRegexParser extends CommonParser {
     // The first group would be the kanji, and the second group the furigana
     abstract get regex() : RegExp;
 
-    get slashCommandTitle () {
-        return 'Anki furigana';
-    }
-
     hasFurigana(content: string): boolean {
         return this.regex.test(content);
     }
@@ -35,12 +31,12 @@ export abstract class SimpleRegexParser extends CommonParser {
 
             last = toReplace.splitText(end)
             toReplace.replaceWith(ruby)
-            console.log(ruby)
-            console.log(start)
-            console.log(end)
-            console.log(toReplace)
-            console.log(last)
-            console.log(text)
+            // console.log(ruby)
+            // console.log(start)
+            // console.log(end)
+            // console.log(toReplace)
+            // console.log(last)
+            // console.log(text)
         }
 
         return text

--- a/src/parsers/SimpleRegexParser.tsx
+++ b/src/parsers/SimpleRegexParser.tsx
@@ -1,0 +1,52 @@
+import { CommonParser } from "./CommonParser";
+
+export abstract class SimpleRegexParser extends CommonParser {
+    // The first group would be the kanji, and the second group the furigana
+    abstract get regex() : RegExp;
+
+    get slashCommandTitle () {
+        return 'Anki furigana';
+    }
+
+    hasFurigana(content: string): boolean {
+        return this.regex.test(content);
+    }
+
+    toNode(text: Text) : Node {
+        console.log("Inside toNode: " + text.textContent!)
+        console.log(text.textContent!.match(this.regex))
+        let last = text
+
+        for (const match of text.textContent!.matchAll(this.regex) ) {
+            console.log(match)
+            const kanji = match[1]
+            const furi = match[2]
+
+            // Create the ruby
+            const ruby = document.createElement('ruby')
+            // ruby.appendChild(document.createTextNode("Holi?"))
+            ruby.innerHTML = `${kanji}<rt>${furi}</rt>`
+
+            // Replace it
+            const start = last.textContent!.indexOf(match[0])
+            const end = match[0].length
+
+            const toReplace = last.splitText(start)
+
+            last = toReplace.splitText(end)
+            toReplace.replaceWith(ruby)
+            console.log(ruby)
+            console.log(start)
+            console.log(end)
+            console.log(toReplace)
+            console.log(last)
+            console.log(text)
+        }
+
+        return text
+    }
+
+    toHtml(content: string) : string {
+        return content.replace(this.regex, this.furiganaHTMLTemplateSimple);
+    }
+}

--- a/src/parsers/SimpleRegexParser.tsx
+++ b/src/parsers/SimpleRegexParser.tsx
@@ -9,21 +9,22 @@ export abstract class SimpleRegexParser extends CommonParser {
     }
 
     toNode(text: Text) : Node {
-        console.log("Inside toNode: " + text.textContent!)
-        console.log(text.textContent!.match(this.regex))
         let last = text
+        console.log("Inside toNode" + text.textContent!)
+        console.log(text.textContent!.match(this.regex))
 
-        for (const match of text.textContent!.matchAll(this.regex) ) {
-            console.log(match)
-            const kanji = match[1]
-            const furi = match[2]
-
-            // Create the ruby
+        for (const match of text.textContent!.matchAll(this.regex)) {
+            const furi = match[2].includes('|') ? match[2].split('|').slice(1) : [ match[2] ]
+            const kanji = furi.length === 1 ? [match[1]] : match[1].split('')
+            
             const ruby = document.createElement('ruby')
-            // ruby.appendChild(document.createTextNode("Holi?"))
-            ruby.innerHTML = `${kanji}<rt>${furi}</rt>`
+            kanji.forEach((k,i) => {
+                ruby.appendChild(document.createTextNode(k));
+                const rt = document.createElement('rt')
+                rt.appendChild(document.createTextNode(furi[i]))
+                ruby.appendChild(rt)
+            })
 
-            // Replace it
             const start = last.textContent!.indexOf(match[0])
             const end = match[0].length
 
@@ -31,12 +32,13 @@ export abstract class SimpleRegexParser extends CommonParser {
 
             last = toReplace.splitText(end)
             toReplace.replaceWith(ruby)
-            // console.log(ruby)
-            // console.log(start)
-            // console.log(end)
-            // console.log(toReplace)
-            // console.log(last)
-            // console.log(text)
+
+            console.log(ruby)
+            console.log(start)
+            console.log(end)
+            console.log(toReplace)
+            console.log(last)
+            console.log(text)
         }
 
         return text

--- a/src/parsers/SumitsukikakkoFuriganaParser.tsx
+++ b/src/parsers/SumitsukikakkoFuriganaParser.tsx
@@ -1,0 +1,7 @@
+import { SimpleRegexParser } from "./SimpleRegexParser";
+
+export class SumitsukikakkoFuriganaParser extends SimpleRegexParser {
+    get regex() : RegExp {
+        return /(\S+)\u{3010}(\S+)\u{3011}/gmu
+    }
+}

--- a/src/parsers/SumitsukikakkoFuriganaParser.tsx
+++ b/src/parsers/SumitsukikakkoFuriganaParser.tsx
@@ -1,6 +1,14 @@
 import { SimpleRegexParser } from "./SimpleRegexParser";
 
 export class SumitsukikakkoFuriganaParser extends SimpleRegexParser {
+    get configKey() : string {
+        return "sumitsukikakko"
+    }
+
+    get description() : string {
+        return "Uses Japanese filled brackets `漢字【かんじ】`"
+    }
+
     get slashCommandTitle() : string {
         return "Sumitsukikakko furigana"
     }

--- a/src/parsers/SumitsukikakkoFuriganaParser.tsx
+++ b/src/parsers/SumitsukikakkoFuriganaParser.tsx
@@ -1,6 +1,10 @@
 import { SimpleRegexParser } from "./SimpleRegexParser";
 
 export class SumitsukikakkoFuriganaParser extends SimpleRegexParser {
+    get slashCommandTitle() : string {
+        return "Sumitsukikakko furigana"
+    }
+
     get regex() : RegExp {
         return /(\S+)\u{3010}(\S+)\u{3011}/gmu
     }


### PR DESCRIPTION
This PR aims to add the feature of rendering any markdown furigana it encounters, via a MutationObserver

- [x] Merge the ObsidianFuriganaParser into SimpleRegexParser (but with `|` functionality)
- [x] Create a configuration menu with togglers for all parsers. If a parser is toggled off, it won't be run
- [x] Deprecate the `toHTML` function and its slash commands, or do something that uses `toNode` to avoid repeated code
- [x] Clean console.logs and the hideous squares